### PR TITLE
Allow braces for multi-line blocks in specs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,7 +17,7 @@ Bundler/OrderedGems:
   Enabled: false
 
 Layout/AlignHash:
-  EnforcedLastArgumentHashStyle: 'ignore_implicit'
+  EnforcedLastArgumentHashStyle: ignore_implicit
 
 Layout/AlignParameters:
   Enabled: false
@@ -29,7 +29,7 @@ Layout/EmptyLineBetweenDefs:
   AllowAdjacentOneLineDefs: true
 
 Layout/MultilineMethodCallIndentation:
-  EnforcedStyle: 'indented'
+  EnforcedStyle: indented
 
 Layout/EndAlignment:
   AutoCorrect: true
@@ -38,10 +38,10 @@ Layout/FirstParameterIndentation:
   Enabled: false
 
 Layout/IndentArray:
-  EnforcedStyle: 'consistent'
+  EnforcedStyle: consistent
 
 Layout/IndentHash:
-  EnforcedStyle: 'consistent'
+  EnforcedStyle: consistent
 
 Lint/ShadowingOuterLocalVariable:
   Enabled: false
@@ -59,7 +59,7 @@ Metrics/BlockLength:
 Metrics/LineLength:
   Max: 120
   Exclude:
-    - 'Gemfile'
+    - Gemfile
     - 'spec/**/*'
     - 'db/**/*'
   IgnoredPatterns: ['\A#']
@@ -74,7 +74,7 @@ Rails/SkipsModelValidations:
   Enabled: false
 
 Style/Alias:
-  EnforcedStyle: 'prefer_alias_method'
+  EnforcedStyle: prefer_alias_method
 
 Style/Documentation:
   Enabled: false
@@ -83,13 +83,13 @@ Style/EmptyCaseCondition:
   Enabled: false
 
 Style/EmptyMethod:
-  EnforcedStyle: 'compact'
+  EnforcedStyle: compact
 
 Style/FrozenStringLiteralComment:
   Enabled: false
 
 Style/Lambda:
-  EnforcedStyle: 'literal'
+  EnforcedStyle: literal
 
 Style/MultilineBlockChain:
   Enabled: false
@@ -101,7 +101,7 @@ Style/StructInheritance:
   Enabled: false
 
 Style/BlockDelimiters:
-  EnforcedStyle: 'braces_for_chaining'
+  EnforcedStyle: braces_for_chaining
 
 Style/AccessModifierDeclarations:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -102,3 +102,6 @@ Style/StructInheritance:
 
 Style/BlockDelimiters:
   EnforcedStyle: 'braces_for_chaining'
+
+Style/AccessModifierDeclarations:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -99,3 +99,6 @@ Style/RescueStandardError:
 
 Style/StructInheritance:
   Enabled: false
+
+Style/BlockDelimiters:
+  EnforcedStyle: 'braces_for_chaining'


### PR DESCRIPTION
### Problem

- `Style/BlockDelimiters`

Rubocop reports this warning `Style/BlockDelimiters: Avoid using {...} for multi-line blocks.`
We want to adhere to that rule, but we want to make an exception in specs for this construct:

```ruby
expect {
  receive_event
}.to change { lock.reload.connected }.from(false).to(true)
```

And in general we want to allow braces for chaining.

- `Style/AccessModifierDeclarations`

We want to allow this `private *delegate(:foo, to: :bar)`

### Solution

Code in this PR.