### PR TITLE
Enable using explicit block arguments

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -105,3 +105,6 @@ Style/BlockDelimiters:
 
 Style/AccessModifierDeclarations:
   Enabled: false
+
+Performance/RedundantBlockCall:
+  Enabled: false


### PR DESCRIPTION
### Problem

Rubocop complains about this:

```ruby
def foo(&block)
  block.call
end
```

Rubocop wants us to use:

```ruby
def foo
  yield
end
```

### Solution

We want to always use explicit block arguments so that function signature is easier to read and a developer can easily spot the `block` arg. For this reason, we want to disable the above described check.