### PR TITLE
Exclude specs from AmbiguousBlockAssociation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -50,6 +50,10 @@ Lint/UselessAccessModifier:
   ContextCreatingMethods:
     - concerning
 
+Lint/AmbiguousBlockAssociation:
+  Exclude:
+    - "spec/**/*"
+
 Metrics/AbcSize:
   Enabled: false
 


### PR DESCRIPTION
`Lint/AmbiguousBlockAssociation` expects us to write a spec like

```ruby
        expect {
          ...
        }.not_to change {
          ...
        }
```

as

```ruby
        expect {
          ...
        }.not_to(change {
          ...
        })
```

But that first way of using `change` is intentional in the rspec DSL