### PR TITLE
Disable Rails/NotNullColumn

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -86,6 +86,9 @@ Rails/DynamicFindBy:
 Rails/HttpPositionalArguments:
   Enabled: false
 
+Rails/NotNullColumn:
+  Enabled: false
+
 Rails/SkipsModelValidations:
   Enabled: false
 


### PR DESCRIPTION
Cop description [link](https://rubocop-rails.readthedocs.io/en/stable/cops_rails/#railsnotnullcolumn)

### Problem

I'm adding a new non-nullable column, and rubocop complains. This is not ok with rubocop: `add_column :tables, :attr, null: false

### Solution

Disable this bad cop.